### PR TITLE
Improve setup script

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -50,11 +50,6 @@ const questions = [
     when: !argv.accessToken,
     message: 'Your Content Delivery API access token',
   },
-  {
-    name: 'previewToken',
-    when: !argv.previewToken,
-    message: 'Your Content Preview API access token',
-  },
 ]
 
 inquirer
@@ -64,7 +59,6 @@ inquirer
     spaceId = spaceId || argv,spaceId
     managementToken = managementToken || argv.managementToken
     deliveryToken = deliveryToken || argv.deliveryToken
-    previewToken = previewToken || argv.previewToken
 
     console.log('Writing config file...')
     const configFilePath = path.resolve(__dirname, '..', '.contentful.json')
@@ -72,15 +66,8 @@ inquirer
       configFilePath,
       JSON.stringify(
         {
-          development: {
-            host: 'preview.contentful.com',
-            spaceId,
-            accessToken: previewToken,
-          },
-          production: {
-            spaceId,
-            accessToken,
-          },
+          spaceId,
+          accessToken: deliveryToken,
         },
         null,
         2

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -5,6 +5,8 @@ const chalk = require('chalk')
 const path = require('path')
 const { writeFileSync } = require('fs')
 
+const argv = require('yargs-parser')(process.argv.slice(2))
+
 console.log(`
   To set up this project you need to provide your Space ID
   and the belonging API access tokens.
@@ -33,27 +35,37 @@ const questions = [
   {
     name: 'spaceId',
     message: 'Your Space ID',
+    when: !argv.spaceId,
     validate: input =>
       /^[a-z0-9]{12}$/.test(input) ||
       'Space ID must be 12 lowercase characters',
   },
   {
     name: 'managementToken',
+    when: !argv.managementToken,
     message: 'Your Content Management API access token',
   },
   {
-    name: 'accessToken',
+    name: 'deliveryToken',
+    when: !argv.accessToken,
     message: 'Your Content Delivery API access token',
   },
   {
     name: 'previewToken',
+    when: !argv.previewToken,
     message: 'Your Content Preview API access token',
   },
 ]
 
 inquirer
   .prompt(questions)
-  .then(({ spaceId, managementToken, accessToken, previewToken }) => {
+  .then(({ spaceId, managementToken, deliveryToken, previewToken }) => {
+
+    spaceId = spaceId || argv,spaceId
+    managementToken = managementToken || argv.managementToken
+    deliveryToken = deliveryToken || argv.deliveryToken
+    previewToken = previewToken || argv.previewToken
+
     console.log('Writing config file...')
     const configFilePath = path.resolve(__dirname, '..', '.contentful.json')
     writeFileSync(

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -54,7 +54,7 @@ const questions = [
 
 inquirer
   .prompt(questions)
-  .then(({ spaceId, managementToken, deliveryToken, previewToken }) => {
+  .then(({ spaceId, managementToken, deliveryToken }) => {
 
     spaceId = spaceId || argv.spaceId
     managementToken = managementToken || argv.managementToken

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -56,7 +56,7 @@ inquirer
   .prompt(questions)
   .then(({ spaceId, managementToken, deliveryToken, previewToken }) => {
 
-    spaceId = spaceId || argv,spaceId
+    spaceId = spaceId || argv.spaceId
     managementToken = managementToken || argv.managementToken
     deliveryToken = deliveryToken || argv.deliveryToken
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,9 +7,7 @@ module.exports = {
     'gatsby-plugin-react-helmet',
     {
       resolve: 'gatsby-source-contentful',
-      options: process.env.NODE_ENV === 'development' ?
-        contentfulConfig.development :
-        contentfulConfig.production
+      options: contentfulConfig
     },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15821,8 +15821,7 @@
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "y18n": "3.2.1"
           }
         }
       }
@@ -19579,8 +19578,7 @@
         "set-blocking": "2.0.0",
         "string-width": "2.1.1",
         "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "y18n": "3.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -19613,9 +19611,9 @@
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
+      "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
       "requires": {
         "camelcase": "4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "gatsby-source-contentful": "^1.3.38",
     "gatsby-transformer-remark": "^1.7.32",
     "inquirer": "^5.1.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "yargs-parser": "^10.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",


### PR DESCRIPTION
This PR makes the setup script accepts the configurations as command line arguments.
e.g:
`npm run setup -- --spaceId <space-id> --managementToken <token>`
If the one of the argument is not passed the script will still ask for it.

TODO: 
- [x] ~Add Netlify toml file~ (https://github.com/contentful-userland/gatsby-contentful-starter/pull/14)