### PR TITLE
Add support for heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "name": "Contentful Gatsby Starter",
+  "description": "Gatsby starter for a Contentful project.",
+  "keywords": [
+    "contentful",
+    "gatsby",
+    "static",
+    "ssg"
+  ],
+  "repository": "https://github.com/contentful-userland/gatsby-contentful-starter",
+  "success_url": "/",
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-static"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
     "fix-semi": "eslint --quiet --ignore-pattern node_modules --ignore-pattern public --parser babel-eslint --no-eslintrc --rule '{\"semi\": [2, \"never\"], \"no-extra-semi\": [2]}' --fix *.js bin/*.js",
     "postinstall": "node ./bin/hello.js",
-    "setup": "node ./bin/setup.js"
+    "setup": "node ./bin/setup.js",
+    "heroku-postbuild": "gatsby build"
   }
 }

--- a/static.json
+++ b/static.json
@@ -1,0 +1,8 @@
+{
+  "root": "public/",
+  "headers": {
+    "/**.js": {
+      "Cache-Control": "public, max-age=0, must-revalidate"
+    }
+  }
+}


### PR DESCRIPTION
This PR makes the smallest changes needed to make this app deployable
to heroku. It relies on [heroku-buildpack-static][1] and
[Heroku specific buildsteps][2].

Do note that this PR adds nothing wrt the credentials needed by this
project. For example, the space id, CDA token, etc. This needs to be tackled separately.

[1]: https://github.com/heroku/heroku-buildpack-static
[2]: https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps

@Khaledgarbaya for the reasoning behind this PR, please talk to JP! (he isn't in this org yet)