### PR TITLE
Fix ID for person query - fix #23

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,7 +56,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    allContentfulPerson(filter: { id: { eq: "c15jwOBqpxqSAOy2eOO4S0m" } }) {
+    allContentfulPerson(filter: { id: { eq: "15jwOBqpxqSAOy2eOO4S0m" } }) {
       edges {
         node {
           name


### PR DESCRIPTION
As pointed out in #23 the ID's for the query are not matching. There is a type in the ID (prepended `c`) and this accidentally works in Gatsby V1 but breaks in V2. :) 

[As you see](https://github.com/contentful-userland/gatsby-contentful-starter/blob/master/contentful/export.json#L463) the ID is without the leading `c`.