### PR TITLE
Updated gatsby-config because of an error at Netlify: Cannot read property 'accessToken' of undefined

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,8 +7,8 @@ try {
 
 // Overwrite the Contentful config with environment variables if they exist
 contentfulConfig = {
-  spaceId: process.env.CONTENTFUL_SPACE_ID || contentfulConfig.spaceId,
-  accessToken: process.env.CONTENTFUL_DELIVERY_TOKEN || contentfulConfig.accessToken,
+  spaceId: process.env.CONTENTFUL_SPACE_ID || contentfulConfig.spaceId || '',
+  accessToken: process.env.CONTENTFUL_DELIVERY_TOKEN || contentfulConfig.accessToken || '',
 }
 
 const { spaceId, accessToken } = contentfulConfig


### PR DESCRIPTION
The error that occurred at Netlify was:

```
Executing user command: gatsby build
4:43:21 PM: success delete html and css files from previous builds — 0.052 s
4:43:21 PM: error We encountered an error while trying to load your site's gatsby-config. Please fix the error and try again.
4:43:21 PM: 
4:43:21 PM:   TypeError: Cannot read property 'accessToken' of undefined
4:43:21 PM:   
4:43:21 PM:   - gatsby-config.js:11 Object.<anonymous>
4:43:21 PM:     /opt/build/repo/gatsby-config.js:11:74
4:43:21 PM:   
4:43:21 PM:   - v8-compile-cache.js:178 Module._compile
4:43:21 PM:     [repo]/[v8-compile-cache]/v8-compile-cache.js:178:30
4:43:21 PM:   
4:43:21 PM:   - v8-compile-cache.js:159 require
4:43:21 PM:     [repo]/[v8-compile-cache]/v8-compile-cache.js:159:20
4:43:21 PM:   
4:43:21 PM:   - get-config-file.js:36 _callee$
4:43:21 PM:     [repo]/[gatsby]/dist/bootstrap/get-config-file.js:36:28
4:43:21 PM:   
4:43:21 PM: 
```

After this change it worked perfect.