### PR TITLE
Add the tag to the article preview

### DIFF
--- a/src/components/article-preview.js
+++ b/src/components/article-preview.js
@@ -16,5 +16,10 @@ export default ({ article }) => (
         __html: article.description.childMarkdownRemark.html,
       }}
     />
+    {article.tags.map(tag => (
+      <p className={styles.tag} key={tag}>
+        {tag}
+      </p>
+    ))}
   </div>
 )


### PR DESCRIPTION
This is some ground work for issue #3, including the tag makes the article previews look more complete. The CSS was already there. Now it's a matter of adding a link to a tags page where you can see everything with the same tag.