### PR TITLE
Query `site.siteMetadata` so the title is populated

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,7 +21,7 @@ if (!spaceId || !accessToken) {
 
 module.exports = {
   siteMetadata: {
-    siteTitle: 'Gatsby Contentful starter',
+    title: 'Gatsby Contentful starter',
   },
   pathPrefix: '/gatsby-contentful-starter',
   plugins: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,6 +20,9 @@ if (!spaceId || !accessToken) {
 }
 
 module.exports = {
+  siteMetadata: {
+    siteTitle: 'Gatsby Contentful starter',
+  },
   pathPrefix: '/gatsby-contentful-starter',
   plugins: [
     'gatsby-transformer-remark',

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -40,6 +40,11 @@ export default BlogIndex
 
 export const pageQuery = graphql`
   query BlogIndexQuery {
+    site {
+      siteMetadata {
+        title
+      }
+    }
     allContentfulBlogPost(sort: { fields: [publishDate], order: DESC }) {
       edges {
         node {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,6 +39,11 @@ export default RootIndex
 
 export const pageQuery = graphql`
   query HomeQuery {
+    site {
+      siteMetadata {
+        title
+      }
+    }
     allContentfulBlogPost(sort: { fields: [publishDate], order: DESC }) {
       edges {
         node {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -44,6 +44,11 @@ export default BlogPostTemplate
 
 export const pageQuery = graphql`
   query BlogPostBySlug($slug: String!) {
+    site {
+      siteMetadata {
+        title
+      }
+    }
     contentfulBlogPost(slug: { eq: $slug }) {
       title
       publishDate(formatString: "MMMM Do, YYYY")


### PR DESCRIPTION
This pull requests resolves Issue #37, `site.siteMetaData` is not being queried. The title could be changed, but 'Gatsby Contentful starter' is a good start.