### PR TITLE
check for tags before mapping to prevent error

### DIFF
--- a/src/components/article-preview.js
+++ b/src/components/article-preview.js
@@ -16,7 +16,7 @@ export default ({ article }) => (
         __html: article.description.childMarkdownRemark.html,
       }}
     />
-    {article.tags.map(tag => (
+    {article.tags && article.tags.map(tag => (
       <p className={styles.tag} key={tag}>
         {tag}
       </p>


### PR DESCRIPTION
Fix for issue #53 to prevent errors when there are no tags within a blog post.