### PR TITLE
feat: adjust cleanup-repository to remove bin and update package.json

### DIFF
--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const rawdata = fs.readFileSync(path.resolve(__dirname, '../package.json'))
+
+let packageJSON = JSON.parse(rawdata)
+delete packageJSON.scripts['setup']
+delete packageJSON.scripts['postinstall']
+delete packageJSON.scripts['cleanup-repository']
+
+let data = JSON.stringify(packageJSON)
+fs.writeFileSync(path.resolve(__dirname, '../package.json'), data)

--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -8,5 +8,5 @@ delete packageJSON.scripts['setup']
 delete packageJSON.scripts['postinstall']
 delete packageJSON.scripts['cleanup-repository']
 
-let data = JSON.stringify(packageJSON)
+let data = JSON.stringify(packageJSON, null, 2)
 fs.writeFileSync(path.resolve(__dirname, '../package.json'), data)

--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -2,9 +2,8 @@
 
 const fs = require('fs')
 const path = require('path')
-const rawdata = fs.readFileSync(path.resolve(__dirname, '../package.json'))
+let packageJSON = require(path.resolve(__dirname, '../package.json'))
 
-let packageJSON = JSON.parse(rawdata)
 delete packageJSON.scripts['setup']
 delete packageJSON.scripts['postinstall']
 delete packageJSON.scripts['cleanup-repository']

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "setup": "node ./bin/setup.js",
     "start": "npm run develop",
     "heroku-postbuild": "gatsby build",
-    "cleanup-repository": "rimraf bin contentful && yarn remove contentful-import chalk inquirer rimraf "
+    "cleanup-repository": "rimraf contentful && yarn remove contentful-import chalk inquirer && node ./bin/cleanup.js && rimraf bin"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "setup": "node ./bin/setup.js",
     "start": "npm run develop",
     "heroku-postbuild": "gatsby build",
-    "cleanup-repository": "rimraf contentful && yarn remove contentful-import chalk inquirer && node ./bin/cleanup.js && rimraf bin"
+    "cleanup-repository": "yarn remove contentful-import chalk inquirer && node ./bin/cleanup.js && rimraf bin contentful"
   }
 }


### PR DESCRIPTION
After running `yarn run cleanup-repository` it will delete the following keys in `package.json`
```
setup
postinstall
cleanup-repository
```
This will make sure to remove unnecessary in the repo as well in deployment. 
 For more details lease check #69, thank you.