### PR TITLE
require the same node version as Gatsby

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "rimraf": "^3.0.2",
     "yargs-parser": "^18.1.3"
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "homepage": "https://github.com/contentful-userland/gatsby-contentful-starter#readme",
   "keywords": [
     "gatsby",


### PR DESCRIPTION
Gatsby requires node 10 since December of 2019. We should do this as well.