### PR TITLE
Fixing missing comma in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
         "loose": true,
         "modules": false,
         "useBuiltIns": "usage",
-        "corejs": "^2.1.*"
+        "corejs": "^2.1.*",
         "shippedProposals": true,
         "targets": {
           "browsers": [">0.25%", "not dead"],


### PR DESCRIPTION
Adding missing comma in the `.babelrc` file that causes `yarn run dev` to fail.